### PR TITLE
Patched with 0008_fix_DMA_buffer_control.patch

### DIFF
--- a/drivers/media/pci/ddbridge/ddbridge-core.c
+++ b/drivers/media/pci/ddbridge/ddbridge-core.c
@@ -492,7 +492,7 @@ static void ddb_output_start(struct ddb_output *output)
 			  DMA_BUFFER_SIZE(output->dma));
 		ddbwritel(dev, 0, DMA_BUFFER_ACK(output->dma));
 		ddbwritel(dev, 1, DMA_BASE_READ);
-		ddbwritel(dev, 3, DMA_BUFFER_CONTROL(output->dma));
+		ddbwritel(dev, 7, DMA_BUFFER_CONTROL(output->dma));
 	}
 
 	ddbwritel(dev, con | 1, TS_CONTROL(output));


### PR DESCRIPTION
The DMA buffer was not fully initialized, which leads to old data read
out from the secX device. Thuis resulted in "invalid MTD number" loggings
in VDR.
Got the Patch from Ralph M. per eMail.

Signed-off-by: Ralph Metzler <rjkm@metzlerbros.de>
Signed-off-by: Jasmin Jessich <jasmin@anw.at>